### PR TITLE
Fix severe bug in LICORS kmeanspp distance matrix

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: motifcluster
 Title: Motif-Based Spectral Clustering of Weighted Directed Networks
-Version: 0.2.2
+Version: 0.2.3
 Authors@R:
     person(given = "William George",
         family = "Underwood",

--- a/R/NEWS.md
+++ b/R/NEWS.md
@@ -1,3 +1,8 @@
+# motifcluster 0.2.3 (2022-11-17)
+
+- Fixed bug in kmeans++ implementation inherited from the
+  deprecated LICORS package.
+
 # motifcluster 0.2.2 (2022-08-15)
 
 - Updating tests for compatability with forthcoming Matrix 1.4-2 package

--- a/R/R/clustering.R
+++ b/R/R/clustering.R
@@ -67,17 +67,18 @@ kmeanspp <- function(data, k = 2, iter.max = 100, nstart = 10, ...) {
     center_ids <- rep(0, length = kk)
     center_ids[1:2] <- sample.int(num.samples, 1)
     for (ii in 2:kk) { # the plus-plus step in kmeans
-       if (ndim == 1) {
-            dists <- apply(cbind(data[center_ids, ]), 1, 
-              function(center) {
-                rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
-              })
-        }
-        else {
-            dists <- apply(data[center_ids, ], 1, function(center) {
-              rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
-            })
-        }      probs <- apply(dists, 1, min)
+      if (ndim == 1) {
+        dists <- apply(cbind(data[center_ids, ]), 1,
+                       function(center) {
+                         rowSums((data - rep(center, each = nrow(data)))^2)
+                       })
+      } else {
+        dists <- apply(data[center_ids, ], 1,
+                       function(center) {
+                         rowSums((data - rep(center, each = nrow(data)))^2)
+                       })
+      }
+      probs <- apply(dists, 1, min)
       probs[center_ids] <- 0
       center_ids[ii] <- sample.int(num.samples, 1, prob = probs)
     }

--- a/R/R/clustering.R
+++ b/R/R/clustering.R
@@ -67,18 +67,17 @@ kmeanspp <- function(data, k = 2, iter.max = 100, nstart = 10, ...) {
     center_ids <- rep(0, length = kk)
     center_ids[1:2] <- sample.int(num.samples, 1)
     for (ii in 2:kk) { # the plus-plus step in kmeans
-      if (ndim == 1) {
-        dists <- apply(cbind(data[center_ids, ]), 1,
-                       function(center) {
-                         rowSums((data - center)^2)
-                       })
-      } else {
-        dists <- apply(data[center_ids, ], 1,
-                       function(center) {
-                         rowSums((data - center)^2)
-                       })
-      }
-      probs <- apply(dists, 1, min)
+       if (ndim == 1) {
+            dists <- apply(cbind(data[center_ids, ]), 1, 
+              function(center) {
+                rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
+              })
+        }
+        else {
+            dists <- apply(data[center_ids, ], 1, function(center) {
+              rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
+            })
+        }      probs <- apply(dists, 1, min)
       probs[center_ids] <- 0
       center_ids[ii] <- sample.int(num.samples, 1, prob = probs)
     }

--- a/R/cran-comments.md
+++ b/R/cran-comments.md
@@ -1,3 +1,9 @@
+# motifcluster 0.2.3
+
+Fixed bug in kmeans++ implementation inherited from the
+deprecated LICORS package.
+
+
 # motifcluster 0.2.2
 
 Updating tests for compatability with forthcoming Matrix 1.4-2 package

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,3 +1,7 @@
+# motifcluster 0.2.3 (2022-11-17)
+
+- Bump version to keep track with R
+
 # motifcluster 0.2.2 (2022-08-15)
 
 - Bump version to keep track with R

--- a/python/doc/conf.py
+++ b/python/doc/conf.py
@@ -24,7 +24,7 @@ copyright = '2020, William George Underwood'
 author = 'William George Underwood, Andrew Elliott'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.2'
+release = '0.2.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as f:
 
 setuptools.setup(
   name='motifcluster',
-  version='0.2.2',
+  version='0.2.3',
   description='Motif-Based Spectral Clustering of Weighted Directed Networks',
   license="GPLv3",
   long_description=long_description,


### PR DESCRIPTION
In Nov. 2021, Bernd Fritzke [reported & fixed](https://www.mail-archive.com/r-help@r-project.org/msg263971.html) a severe bug in the LICORS kmeanspp distance matrix calculation.  The bug resulted in poor performance equivalent to naive init (rather than k-means++).  Motifcluster appears to have copied that code verbatim, including the bug.  

Bernd reports:
> In its current form, the results were much worse than those of Hartigan-Wong (the default for k-means in the stats 
package) for all test problems I tried. However, after fixing the bug, kmeanspp found better results than Hartigan-Wong for all those problems.

In summary:
> The bug concerns a distance computation which should be a matrix of distances of all data vectors and all current codebook vectors, but is not. The code and an example illustrating the problem is shown below. Basically, to subtract a vector from a matrix, one has to convert the vector into a matrix where all rows are just copies of the vector. ... The fix is trivial.


See also this [post by Paul Harrison](https://logarithmic.net/pfh-files/blog/01618034037/k-means-better.html), who also noticed sub-optimal results.  When I [compared these to scikit-learn](https://ctwardy.micro.blog/2021/06/10/on-kmeans-clustering.html), I discovered the results were as if the inits were still naive (random).  

Bernd's analysis would explain that -- and appears to fix it.

I have also made this pull request in the (unmaintained) LICORS package.